### PR TITLE
Input and proof

### DIFF
--- a/lib/bsv/transaction/transaction.js
+++ b/lib/bsv/transaction/transaction.js
@@ -290,15 +290,18 @@ Transaction.prototype.fromBufferReader = function (reader) {
   var i, sizeTxIns, sizeTxOuts
 
   this.version = reader.readInt32LE()
+
   sizeTxIns = reader.readVarintNum()
   for (i = 0; i < sizeTxIns; i++) {
     var input = Input.fromBufferReader(reader)
     this.inputs.push(input)
   }
+
   sizeTxOuts = reader.readVarintNum()
   for (i = 0; i < sizeTxOuts; i++) {
     this.outputs.push(Output.fromBufferReader(reader))
   }
+  
   this.nLockTime = reader.readUInt32LE()
   return this
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -21,6 +21,8 @@ export { Metadata }
 export { Utils }
 export { Output } from './output'
 export { Puzzle } from './puzzle'
+export { Input } from './input'
+export { Proof } from './proof'
 
 export { BoostPowString } from './work/string'
 export { Job as BoostPowJob }

--- a/lib/input.ts
+++ b/lib/input.ts
@@ -1,0 +1,53 @@
+import * as bsv from './bsv'
+import { Redeem } from './redeem'
+import { Digest32 } from './fields/digest32'
+
+// Input represents an input that redeems a boost job, as opposed to Redeem,
+// which is merely a script and optionally an input. Whereas the parameters
+// txid, vin, spentTxid, and spentVout are optional in Redeem, they are required
+// here, either given explicitly in the constructor or having been given in the
+// Redeem class.
+export class Input {
+  script: Redeem
+  _txid?: Digest32 | undefined
+  _vin?: number | undefined
+  _spentTxid?: Digest32 | undefined
+  _spentVout?: number | undefined
+
+  constructor(script: Redeem, txid?: Digest32, vin?: number, spentTxid?: Digest32, spentVout?: number) {
+    this.script = script
+    if (txid !== undefined) this._txid = txid
+    else if (script.txid === undefined) throw "invalid output: missing parameter txid"
+    if (vin !== undefined) this._vin = vin
+    else if (script.vin === undefined) throw "invalid output: missing parameter vout"
+    if (spentTxid !== undefined) this._txid = txid
+    else if (script.txid === undefined) throw "invalid output: missing parameter txid"
+    if (spentVout !== undefined) this._vin = vin
+    else if (script.vin === undefined) throw "invalid output: missing parameter vout"
+  }
+
+  static fromTransaction(tx: bsv.Transaction | Buffer, vin: number): Input | undefined {
+    let j = Redeem.fromTransaction(tx, vin)
+    if (j) return new Input(j)
+  }
+
+  get txid(): Digest32 {
+    if (this.script.txid) return Digest32.fromHex(this.script.txid)
+    return <Digest32>this._txid
+  }
+
+  get vin(): number {
+    if (this.script.vin) return this.script.vin
+    return <number>this._vin
+  }
+
+  get spentTxid(): Digest32 {
+    if (this.script.spentTxid) return Digest32.fromHex(this.script.spentTxid)
+    return <Digest32>this._spentTxid
+  }
+
+  get spentVout(): number {
+    if (this.script.spentVout) return this.script.spentVout
+    return <number>this._spentVout
+  }
+}

--- a/lib/job.ts
+++ b/lib/job.ts
@@ -491,7 +491,7 @@ export class Job {
       return undefined
     }
 
-    let tx: bsv.Transaction = new bsv.Transaction(t)
+    let tx: bsv.Transaction = t instanceof Buffer || typeof t === 'string' ? new bsv.Transaction(t) : t
 
     if (vout > tx.outputs.length - 1 || vout < 0 || vout === undefined || vout === null) {
       return undefined
@@ -528,8 +528,7 @@ export class Job {
       return undefined
     }
 
-    const tx = new bsv.Transaction(rawtx)
-    return Job.fromTransaction(tx, vout)
+    return Job.fromTransaction(rawtx, vout)
   }
   /**
    * Create a transaction fragment that can be modified to redeem the boost job

--- a/lib/job.ts
+++ b/lib/job.ts
@@ -277,6 +277,7 @@ export class Job {
   }
 
   private static readScript(script: bsv.Script, txid?: string, vout?: number, value?: number): Job {
+
     let category
     let content
     let diff
@@ -420,8 +421,8 @@ export class Job {
     )
   }
 
-  static fromHex(asm: string, txid?: string, vout?: number, value?: number): Job {
-    return Job.readScript(new bsv.Script(asm), txid, vout, value)
+  static fromHex(hex: string, txid?: string, vout?: number, value?: number): Job {
+    return Job.readScript(new bsv.Script(hex), txid, vout, value)
   }
 
   static fromASM(asm: string, txid?: string, vout?: number, value?: number): Job {
@@ -499,7 +500,7 @@ export class Job {
 
     if (tx.outputs[vout].script && tx.outputs[vout].script.chunks[0].buf &&
       tx.outputs[vout].script.chunks[0].buf.toString('hex') === Buffer.from('boostpow', 'utf8').toString('hex')) {
-      return Job.readScript(tx.outputs[vout].script, tx.hash, vout, tx.outputs[vout].satoshis)
+      return Job.readScript(new bsv.Script(tx.outputs[vout].script.toHex()), tx.hash, vout, tx.outputs[vout].satoshis)
     }
 
     return undefined

--- a/lib/proof.ts
+++ b/lib/proof.ts
@@ -1,0 +1,80 @@
+import * as bsv from './bsv'
+import * as work from './work/proof'
+import { Job } from './job'
+import { Output } from './output'
+import { Input } from './input'
+import { Digest32 } from './fields/digest32'
+import { Bytes } from './fields/bytes'
+import { Int32Little } from './fields/int32Little'
+import { UInt32Little } from './fields/uint32Little'
+import { UInt16Little } from './fields/uint16Little'
+import { Difficulty } from './fields/difficulty'
+
+// the Job class may represent a complete output in the blockchain but
+// it may just be a script without other parameters. Output definitely has
+// the satoshi value and outpoint set, which are both necessary for actually
+// redeeming a Boost output.
+export class Proof {
+  lock: Output
+  unlock: Input
+  proof: work.Proof
+
+  constructor(output: Output, input: Input) {
+    this.lock = output
+    this.unlock = input
+    this.proof = Job.proof(output.script, input.script)
+  }
+
+  valid(): boolean {
+    return this.lock.txid === this.unlock.spentTxid &&
+      this.lock.vout == this.unlock.spentVout && this.proof.valid()
+  }
+
+  get content(): Digest32 {
+    return this.lock.script.content
+  }
+
+  get difficulty(): number {
+    return this.lock.script.difficulty
+  }
+
+  get time(): UInt32Little {
+    return this.unlock.script.time
+  }
+
+  get topic(): Bytes {
+    return this.lock.script.tag
+  }
+
+  get tag(): Bytes {
+    return this.lock.script.tag
+  }
+
+  get data(): Bytes {
+    return this.lock.script.additionalData
+  }
+
+  get category(): Int32Little {
+    return this.proof.category
+  }
+
+  get magicNumber(): UInt16Little {
+    return this.proof.magicNumber
+  }
+
+  get lockingTxid(): Digest32 {
+    return this.lock.txid
+  }
+
+  get redeemingTxid(): Digest32 {
+    return this.unlock.txid
+  }
+
+  get vout(): number {
+    return this.lock.vout
+  }
+
+  get vin(): number {
+    return this.unlock.vin
+  }
+}

--- a/lib/redeem.ts
+++ b/lib/redeem.ts
@@ -204,12 +204,17 @@ export class Redeem {
       return buildOut
     }
 
-    static fromTransaction(tx: bsv.Transaction): Redeem | undefined {
+    static fromTransaction(tx: bsv.Transaction, inp?: number): Redeem | undefined {
         if (!tx) {
             return undefined
         }
 
-        let inp = 0
+        if (!!inp) {
+          let input = tx.inputs[inp]
+          return Redeem.fromScript(input.script, tx.hash, inp, input.prevTxId.toString('hex'), input.outputIndex)
+        }
+
+        inp = 0
         for (const input of tx.inputs) {
             try {
                 return Redeem.fromScript(input.script, tx.hash, inp, input.prevTxId.toString('hex'), input.outputIndex)

--- a/lib/work/proof.ts
+++ b/lib/work/proof.ts
@@ -1,6 +1,7 @@
 import * as bsv from '../bsv'
 import { Int32Little } from '../fields/int32Little'
 import { UInt32Little } from '../fields/uint32Little'
+import { UInt16Little } from '../fields/uint16Little'
 import { UInt32Big } from '../fields/uint32Big'
 import { Digest32 } from '../fields/digest32'
 import { Bytes } from '../fields/bytes'
@@ -115,24 +116,42 @@ export function pow_string(p: Puzzle, x: Solution): PowString | undefined {
 
 // TODO the puzzle also needs to contain a Merkle branch but for Boost that is empty.
 export class Proof {
+  String: PowString | undefined
   constructor(
     public Puzzle: Puzzle,
-    public Solution: Solution) {}
+    public Solution: Solution) {
+    this.String = pow_string(this.Puzzle, this.Solution)
+  }
+
+  valid(): boolean {
+    if (this.String) return this.String.valid()
+    return false
+  }
+
+  puzzle(): Puzzle {
+    return this.Puzzle
+  }
+
+  solution(): Solution {
+    return this.Solution
+  }
 
   metadata(): Bytes {
     return meta(this.Puzzle, this.Solution)
   }
 
-  string(): PowString | undefined {
-    return pow_string(this.Puzzle, this.Solution)
+  string(): PowString {
+    if (this.String === undefined) throw "work proof is invalid"
+    return this.String
   }
 
-  valid(): boolean {
-    let x = this.string()
-    if (x) {
-      return x.valid()
-    }
+  get category(): Int32Little {
+    if (this.String === undefined) throw "work proof is invalid"
+    return this.String.category
+  }
 
-    return false
+  get magicNumber(): UInt16Little {
+    if (this.String === undefined) throw "work proof is invalid"
+    return this.String.magicNumber
   }
 }


### PR DESCRIPTION
Add types Input and Proof. Input represents a complete boost input in a transaction. Redeem represents the boost script and has parameters for txid, vin, spentVout, and spentTxid that are optional. In Input, these parameters are not optional. Proof is an Input and an Output together, and represents a complete Boost purchase with proof of work that can be read. 